### PR TITLE
Fixed some errors in catalan translations and changed the way page titles are translated

### DIFF
--- a/Resources/skeleton/crud/views/edit.html.twig.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig.twig
@@ -1,12 +1,12 @@
 {{ "{% extends 'JordiLlonchCrudGeneratorBundle::layout.html.twig' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }} - " ~ entity ~ " {{ 'views.edit.edit'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}
+{{ "{{ parent() }} -  {{ 'views.edit.edit'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}
 {{ "{% endblock %}" }}
 
 {{ "{% block page %}" }}
 
-<h1>{{ entity }} {{ "{{ 'views.edit.edit'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}</h1>
+<h1>{{ "{{ 'views.edit.edit'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}</h1>
 
 <form class="well" action="{{ "{{ path('"~ route_name_prefix ~"_update', { 'id': entity.id }) }}" }}" method="post" {{ "{{ form_enctype(edit_form) }}" }}>
     {{ "{{ form_widget(edit_form) }}" }}

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -1,7 +1,7 @@
 {{ "{% extends 'JordiLlonchCrudGeneratorBundle::layout.html.twig' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }} - " ~ entity ~ " {{ 'views.index.list'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}
+{{ "{{ parent() }} - {{ 'views.index.list'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}
 {{ "{% endblock %}" }}
 
 {{ "{% block page %}" }}
@@ -9,7 +9,7 @@
 <div class="row">
 
     <div class="span8">
-        <h1>{{ entity }} {{ "{{ 'views.index.list'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}</h1>
+        <h1>{{ "{{ 'views.index.list'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}</h1>
     </div>
     <div class="span2">
         {{ '{% if form_errors(filterForm) %}' }}

--- a/Resources/skeleton/crud/views/new.html.twig.twig
+++ b/Resources/skeleton/crud/views/new.html.twig.twig
@@ -1,12 +1,12 @@
 {{ "{% extends 'JordiLlonchCrudGeneratorBundle::layout.html.twig' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }} - " ~ entity ~ " {{ 'views.new.creation'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}
+{{ "{{ parent() }} - {{ 'views.new.creation'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}
 {{ "{% endblock %}" }}
 
 {{ "{% block page %}" }}
 
-<h1>{{ entity }} {{ "{{ 'views.new.creation'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}</h1>
+<h1>{{ "{{ 'views.new.creation'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}</h1>
 
 <form class="well" action="{{ "{{ path('"~ route_name_prefix ~"_create') }}" }}" method="post" {{ "{{ form_enctype(form) }}" }}>
     {{ "{{ form_widget(form) }}" }}

--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -1,7 +1,7 @@
 {{ "{% extends 'JordiLlonchCrudGeneratorBundle::layout.html.twig' %}" }}
 
 {{ "{% block title %}" }}
-{{ "{{ parent() }} - " ~ entity ~ " {{ 'views.show.show'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}
+{{ "{{ parent() }} - {{ 'views.show.show'|trans({'%entity%': '" }}{{ entity }}{{ "'}, 'JordiLlonchCrudGeneratorBundle') }}" }}
 {{ "{% endblock %}" }}
 
 {{ "{% block page %}" }}

--- a/Resources/translations/JordiLlonchCrudGeneratorBundle.ca.yml
+++ b/Resources/translations/JordiLlonchCrudGeneratorBundle.ca.yml
@@ -5,7 +5,7 @@ views:
         filters: Filtres
         filter: Filtrar
         reset: Netejar
-        list: llista
+        list: %entity%: llista
         actions: Accions
         createnew: Crear
         pagprev: '&larr; Anterior'
@@ -19,20 +19,20 @@ views:
         delete: Eliminar
         confirm: Eliminar l'element?
     new:
-        creation: crear
+        creation: Crear %entity%
         create: Crear
     edit:
-        edit: editar
+        edit: Editar %entity%
         editbutton: Editar
     show:
-        show: veure
+        show: Veure %entity%
 flash:
     create:
         success: Element creat satisfactòriament.
         error: Hi ha hagut un error durant la creació de l'element.
     update:
-        success: Elemento actualitzat satisfactòriament.
+        success: Element actualitzat satisfactòriament.
         error: Hi ha hagut un error durant l'actualització de l'element.
     delete:
-        success: Elemento eliminat satisfactòriamente.
-        error: Hi ha hagut un error durante l'eliminació de l'element.
+        success: Element eliminat satisfactòriament.
+        error: Hi ha hagut un error durant l'eliminació de l'element.

--- a/Resources/translations/JordiLlonchCrudGeneratorBundle.en.yml
+++ b/Resources/translations/JordiLlonchCrudGeneratorBundle.en.yml
@@ -5,7 +5,7 @@ views:
         filters: Filters
         filter: Filter
         reset: Reset
-        list: list
+        list: %entity% list
         actions: Actions
         createnew: Create a new
         pagprev: '&larr; Previous'
@@ -19,13 +19,13 @@ views:
         delete: Delete
         confirm: Delete the item?
     new:
-        creation: creation
+        creation: Create %entity%
         create: Create
     edit:
-        edit: edit
+        edit: Edit %entity%
         editbutton: Edit
     show:
-        show: show
+        show: Show %entity%
 flash:
     create:
         success: Item has been successfully created.

--- a/Resources/translations/JordiLlonchCrudGeneratorBundle.es.yml
+++ b/Resources/translations/JordiLlonchCrudGeneratorBundle.es.yml
@@ -5,7 +5,7 @@ views:
         filters: Filtros
         filter: Filtrar
         reset: Limpiar
-        list: lista
+        list: %entity%: lista
         actions: Acciones
         createnew: Crear
         pagprev: '&larr; Anterior'
@@ -19,13 +19,13 @@ views:
         delete: Eliminar
         confirm: Eliminar el elemento?
     new:
-        creation: crear
+        creation: Crear %entity%
         create: Crear
     edit:
-        edit: editar
+        edit: Editar %entity%
         editbutton: Editar
     show:
-        show: ver
+        show: Ver %entity%
 flash:
     create:
         success: Elemento creado satisfactoriamente.


### PR DESCRIPTION
There were some mistranslated strings in the catalan translation.

I also found quite unusual the translations to catalan and spanish of the page headers/titles, so I changed the way they are created to use directly a translation with the entity name as a parameter instead of "hardcoding" it before the page name.
