### PR TITLE
fixing polish translation for SHOW on action listings

### DIFF
--- a/Resources/translations/JordiLlonchCrudGeneratorBundle.pl.yml
+++ b/Resources/translations/JordiLlonchCrudGeneratorBundle.pl.yml
@@ -11,7 +11,7 @@ views:
         pagprev: '&larr; Poprzednia'
         pagnext: 'Następna &rarr;'
     actions:
-        show: lista
+        show: podgląd
         edit: edycja
     recordactions:
         backtothelist: Wróć do listy


### PR DESCRIPTION
Better lang for "show" in polish it's "podgląd" but not "lista" that means "list".
