### PR TITLE
Add escape js filter on js confirm text when a record going to be deleted

### DIFF
--- a/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
+++ b/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
@@ -16,7 +16,7 @@
         <form action="{{ "{{ path('"~ route_name_prefix ~"_delete', { 'id': entity.id }) }}" }}" method="post">
             <input type="hidden" name="_method" value="DELETE" />
             {{ '{{ form_widget(delete_form) }}' }}
-            <button class="btn btn-danger" type="submit" onclick="return confirm('{{ "{{ 'views.recordactions.confirm'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}');">{{ "{{ 'views.recordactions.delete'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}</button>
+            <button class="btn btn-danger" type="submit" onclick="return confirm('{{ "{{ 'views.recordactions.confirm'|trans({}, 'JordiLlonchCrudGeneratorBundle')|escape('js') }}" }}');">{{ "{{ 'views.recordactions.delete'|trans({}, 'JordiLlonchCrudGeneratorBundle') }}" }}</button>
         </form>
     </div>
 {% endif %}


### PR DESCRIPTION
On confirm js for deleting a record, text is not escaped. In some language like French, there's a quote in the confirm text. In that case the confirm dialog don't appear and the row is deleted without user confirmation.