### PR TITLE
Fix empty query error.

### DIFF
--- a/Resources/skeleton/form/FormFilterType.php.twig
+++ b/Resources/skeleton/form/FormFilterType.php.twig
@@ -28,11 +28,11 @@ class {{ form_class }} extends AbstractType
             foreach ($event->getData() as $data) {
                 if(is_array($data)) {
                     foreach ($data as $subData) {
-                        if(!empty($subData)) return;
+                        if(null !== $subData) return;
                     }
                 }
                 else {
-                    if(!empty($data)) return;
+                    if(null !== $data) return;
                 }
             }
 


### PR DESCRIPTION
When a search is done on a number equal to zero or on a false boolean, the fields is considered as empty and the query isn't done.

Check if the fill isn't strictly equal to null fix the problem.